### PR TITLE
chore(license): migrate to MPL-2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,37 +1,4 @@
-SPDX-License-Identifier: PMPL-1.0-or-later
-SPDX-FileCopyrightText: 2024-2026 Jonathan D.A. Jewell (hyperpolymath) <j.d.a.jewell@open.ac.uk>
-
-------------------------------------------------------------------------
-PREFERRED LICENCE: Palimpsest License (PMPL-1.0-or-later)
-------------------------------------------------------------------------
-
-This work is governed by the Palimpsest License (PMPL-1.0-or-later) as
-its primary intended licence. PMPL-1.0-or-later extends the Mozilla
-Public License 2.0 (MPL-2.0) with additional provisions for ethical use,
-post-quantum cryptographic provenance, and emotional lineage protection.
-The canonical PMPL text and stewardship information are maintained at:
-  https://github.com/hyperpolymath/palimpsest-license
-
-------------------------------------------------------------------------
-FALLBACK LICENCE: Mozilla Public License 2.0 (MPL-2.0)
-------------------------------------------------------------------------
-
-Because PMPL-1.0-or-later is not yet recognised by the Open Source
-Initiative (OSI) or equivalent bodies, this work also carries MPL-2.0
-as its legally-recognised fallback licence.
-
-In any jurisdiction, platform, or context where PMPL-1.0-or-later is
-not accepted as a valid licence, or where an OSI-approved licence is
-required, this work is instead governed by the Mozilla Public License,
-Version 2.0.
-
-MPL-2.0 was chosen as the fallback because PMPL-1.0-or-later is
-explicitly based on and extends MPL-2.0; it is therefore the closest
-recognised equivalent to the intended licence.
-
-The complete MPL-2.0 text follows below.
-
-------------------------------------------------------------------------
+SPDX-License-Identifier: MPL-2.0
 
 Mozilla Public License Version 2.0
 ==================================
@@ -70,7 +37,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in
+    means a work that combines Covered Software with other material, in 
     a separate file or files, that is not Covered Software.
 
 1.8. "License"
@@ -109,17 +76,17 @@ Mozilla Public License Version 2.0
     means the form of the work preferred for making modifications.
 
 1.14. "You" (or "Your")
-    means an individual or a legal entity exercising rights under
-    this License. For legal entities, "You" includes any entity that
-    controls, is controlled by, or is under common control with You.
-    For the purposes of this definition, "control" means (a) the power,
-    direct or indirect, to cause the direction or management of such
-    entity, whether by contract or otherwise, or (b) ownership of more
-    than fifty percent (50%) of the outstanding shares or beneficial
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
     ownership of such entity.
 
 2. License Grants and Conditions
----------------------------------
+--------------------------------
 
 2.1. Grants
 
@@ -144,11 +111,11 @@ distributes such Contribution.
 
 2.3. Limitations on Grant Scope
 
-The licenses granted in this Section 2 are the only rights granted
-under this License. No additional rights or licenses will be implied
-from the distribution or licensing of Covered Software under this
-License. Notwithstanding Section 2.1(b) above, no patent license is
-granted by a Contributor:
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
 
 (a) for any code that a Contributor has removed from Covered Software;
     or
@@ -158,19 +125,19 @@ granted by a Contributor:
     Contributions with other software (except as part of its Contributor
     Version); or
 
-(c) under Patent Claims infringed by Covered Software in the absence
-    of its Contributions.
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
 
-This License does not grant any rights in the trademarks, service
-marks, or logos of any Contributor (except as may be necessary to
-comply with the notice requirements in Section 3.4).
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
 
 2.4. Subsequent Licenses
 
 No Contributor makes additional grants as a result of Your choice to
 distribute the Covered Software under a subsequent version of this
-License (see Section 10.2) or under the terms of a Secondary License
-(if permitted under the terms of Section 3.3).
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
 
 2.5. Representation
 
@@ -186,11 +153,11 @@ equivalents.
 
 2.7. Conditions
 
-Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses
-granted in Section 2.1.
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
 
 3. Responsibilities
---------------------
+-------------------
 
 3.1. Distribution of Source Form
 
@@ -207,10 +174,10 @@ Form.
 If You distribute Covered Software in Executable Form then:
 
 (a) such Covered Software must also be made available in Source Code
-    Form, as described in Section 3.1, and You must inform recipients
-    of the Executable Form how they can obtain a copy of such Source
-    Code Form by reasonable means in a timely manner, at a charge no
-    more than the cost of distribution to the recipient; and
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
 
 (b) You may distribute such Executable Form under the terms of this
     License, or sublicense it under different terms, provided that the
@@ -222,8 +189,8 @@ If You distribute Covered Software in Executable Form then:
 You may create and distribute a Larger Work under terms of Your choice,
 provided that You also comply with the requirements of this License for
 the Covered Software. If the Larger Work is a combination of Covered
-Software with a work governed by one or more Secondary Licenses, and
-the Covered Software is not Incompatible With Secondary Licenses, this
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
 License permits You to additionally distribute such Covered Software
 under the terms of such Secondary License(s), so that the recipient of
 the Larger Work may, at their option, further distribute the Covered
@@ -241,28 +208,28 @@ the extent required to remedy known factual inaccuracies.
 3.5. Application of Additional Terms
 
 You may choose to offer, and to charge a fee for, warranty, support,
-indemnity or liability obligations to one or more recipients of
-Covered Software. However, You may do so only on Your own behalf, and
-not on behalf of any Contributor. You must make it absolutely clear
-that any such warranty, support, indemnity, or liability obligation is
-offered by You alone, and You hereby agree to indemnify every
-Contributor for any liability incurred by such Contributor as a result
-of warranty, support, indemnity or liability terms You offer. You may
-include additional disclaimers of warranty and limitations of liability
-specific to any jurisdiction.
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
 
 4. Inability to Comply Due to Statute or Regulation
------------------------------------------------------
+---------------------------------------------------
 
 If it is impossible for You to comply with any of the terms of this
 License with respect to some or all of the Covered Software due to
 statute, judicial order, or regulation then You must: (a) comply with
 the terms of this License to the maximum extent possible; and (b)
-describe the limitations and the code they affect. Such description
-must be placed in a text file included with all distributions of the
-Covered Software under this License. Except to the extent prohibited
-by statute or regulation, such description must be sufficiently
-detailed for a recipient of ordinary skill to be able to understand it.
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
 
 5. Termination
 --------------
@@ -271,27 +238,27 @@ detailed for a recipient of ordinary skill to be able to understand it.
 if You fail to comply with any of its terms. However, if You become
 compliant, then the rights granted under this License from a particular
 Contributor are reinstated (a) provisionally, unless and until such
-Contributor explicitly and finally terminates Your grants, and (b) on
-an ongoing basis, if such Contributor fails to notify You of the
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
 non-compliance by some reasonable means prior to 60 days after You have
 come back into compliance. Moreover, Your grants from a particular
 Contributor are reinstated on an ongoing basis if such Contributor
-notifies You of the non-compliance by some reasonable means, this is
-the first time You have received notice of non-compliance with this
-License from such Contributor, and You become compliant prior to 30
-days after Your receipt of the notice.
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
 
-5.2. If You initiate litigation against any entity by asserting a
-patent infringement claim (excluding declaratory judgment actions,
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
 counter-claims, and cross-claims) alleging that a Contributor Version
 directly or indirectly infringes any patent, then the rights granted to
 You by any and all Contributors for the Covered Software under Section
 2.1 of this License shall terminate.
 
 5.3. In the event of termination under Sections 5.1 or 5.2 above, all
-end user license agreements (excluding distributors and resellers)
-which have been validly granted by You or Your distributors under this
-License prior to termination shall survive termination.
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
 
 ************************************************************************
 *                                                                      *
@@ -346,7 +313,7 @@ Nothing in this Section shall prevent a party's ability to bring
 cross-claims or counter-claims.
 
 9. Miscellaneous
------------------
+----------------
 
 This License represents the complete agreement concerning the subject
 matter hereof. If any provision of this License is held to be
@@ -356,14 +323,14 @@ that the language of a contract shall be construed against the drafter
 shall not be used to construe this License against a Contributor.
 
 10. Versions of the License
-----------------------------
+---------------------------
 
 10.1. New Versions
 
-Mozilla Foundation is the license steward. Except as provided in
-Section 10.3, no one other than the license steward has the right to
-modify or publish new versions of this License. Each version will be
-given a distinguishing version number.
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
 
 10.2. Effect of New Versions
 
@@ -396,13 +363,13 @@ Exhibit A - Source Code Form License Notice
 
 If it is not possible or desirable to put the notice in a particular
 file, then You may include the notice in a location (such as a LICENSE
-file in a relevant directory) where a recipient would be likely to
-look for such a notice.
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
 
 You may add additional accurate notices of copyright ownership.
 
 Exhibit B - "Incompatible With Secondary Licenses" Notice
-----------------------------------------------------------
+---------------------------------------------------------
 
   This Source Code Form is "Incompatible With Secondary Licenses", as
   defined by the Mozilla Public License, v. 2.0.


### PR DESCRIPTION
## Summary
Migrates this repo's license declaration from `PMPL-1.0-or-later` to `MPL-2.0`.

**Rationale:** solo.

## Changes
- LICENSE file replaced with canonical `MPL-2.0` text (including SPDX header).
- Package metadata updated where present (Cargo.toml, package.json, deno.json, mix.exs, pyproject.toml).

Part of estate-wide metadata cleanup 2026-05-26.